### PR TITLE
Fix AM/PM formatting

### DIFF
--- a/strftime.go
+++ b/strftime.go
@@ -146,7 +146,7 @@ func Strftime(t *time.Time, format string) string {
 				continue
 			case 'w', 'u': // w sunday is 0,0..6 u monday is 1,1..7
 				wd := int(t.Weekday() - time.Sunday)
-				if wd == 0 && b[i] == 'u' {
+				if wd == 0 && b[i+1] == 'u' {
 					app(strconv.Itoa(7), &i, 1)
 				} else {
 					app(strconv.Itoa(wd), &i, 1)

--- a/strftime.go
+++ b/strftime.go
@@ -111,10 +111,10 @@ func Strftime(t *time.Time, format string) string {
 				app(fmt.Sprintf("%2s", strconv.Itoa(hki)), &i, 1)
 				continue
 			case 'P':
-				app(t.Format("am"), &i, 1)
+				app(t.Format("pm"), &i, 1)
 				continue
 			case 'p':
-				app(t.Format("AM"), &i, 1)
+				app(t.Format("PM"), &i, 1)
 				continue
 			case 'M':
 				app(t.Format("04"), &i, 1)
@@ -199,7 +199,7 @@ func Strftime(t *time.Time, format string) string {
 					strconv.Itoa(hki),
 					t.Format("04"),
 					t.Format("05"),
-					t.Format("AM")),
+					t.Format("PM")),
 					&i, 1)
 				continue
 			case 'R':

--- a/strftime_test.go
+++ b/strftime_test.go
@@ -57,8 +57,8 @@ func TestFormat(t *testing.T) {
 		"%k": " 9",
 		"%I": "09",
 		"%l": " 9",
-		"%P": "am",
-		"%p": "AM",
+		"%P": "pm",
+		"%p": "PM",
 
 		// Minute
 		"%M": "37",


### PR DESCRIPTION
Go's string formatting uses "pm" or "PM" to show AM/PM when formatting a time. The code was using "am" or "AM" which would always just write out "am" in the formatted string.

@joshua